### PR TITLE
Fix for Error TypeError: Cannot read properties of undefined (reading 'data')

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -17,5 +17,5 @@ outputs:
   jira_release_name:
     description: 'Jira Release Name'
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'

--- a/dist/index.js
+++ b/dist/index.js
@@ -87636,11 +87636,11 @@ async function getJiraTicketsFromCommits() {
   const [latestTag, previousTag] = tags;
 
   const [latestCommit, previousCommit] = await Promise.all([
-    github.repos.getCommit({
+    github.rest.repos.getCommit({
       ...defaultApiParams,
       ref: latestTag.commit.sha,
     }),
-    github.repos.getCommit({
+    github.rest.repos.getCommit({
       ...defaultApiParams,
       ref: previousTag.commit.sha,
     }),
@@ -87651,7 +87651,7 @@ async function getJiraTicketsFromCommits() {
     new Date(previousCommit.data.commit.committer.date).valueOf() + 1000
   ).toISOString();
 
-  const commits = await github.repos.listCommits({
+  const commits = await github.rest.repos.listCommits({
     ...defaultApiParams,
     since,
     until: latestCommit.data.commit.committer.date,

--- a/dist/index.js
+++ b/dist/index.js
@@ -97059,16 +97059,19 @@ async function run() {
     const { tag_name, name } = context.payload.release;
 
     let jiraVersionName = `${context.repo.repo}-${tag_name.replace(/^v/, '')}`;
-	const data = await jiraClient.post('rest/api/3/version', {
-		json: {
-		  name: jiraVersionName,
-		  projectId: coreExports.getInput('project_id'),
-		  description: name,
-		},
-	  }).json();
 
-    coreExports.setOutput('jira_release_id', data.id);
-    coreExports.setOutput('jira_release_name', data.name);
+    const data = await jiraClient
+      .post('rest/api/3/version', {
+        json: {
+          name: jiraVersionName,
+          projectId: coreExports.getInput('project_id'),
+          description: name,
+        },
+      })
+      .json();
+
+    coreExports.setOutput('jira_release_id', data ? data.id : '???');
+    coreExports.setOutput('jira_release_name', data ? data.name : '???');
 
     await setFixVersion(data.name);
   } catch (e) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -97032,20 +97032,30 @@ const jiraClient = got.extend({
  */
 
 async function updateJiraTickets(tickets, jiraVersion) {
-  const promises = tickets.map((t) => {
-    return jiraClient
-      .put(`rest/api/3/issue/${t}`, {
-        json: {
-          update: {
-            fixVersions: [
-              {
-                add: { name: jiraVersion },
-              },
-            ],
+  const promises = tickets.map(async (t) => {
+    try {
+      const response = await jiraClient
+        .put(`rest/api/3/issue/${t}`, {
+          json: {
+            update: {
+              fixVersions: [
+                {
+                  add: { name: jiraVersion },
+                },
+              ],
+            },
           },
-        },
-      })
-      .json()
+        })
+        .json();
+
+      return response
+    } catch (error) {
+      console.error(
+        `Failed to update issue ${t}:`,
+        error.response?.body || error
+      );
+      throw error
+    }
   });
 
   return await Promise.all(promises)

--- a/dist/index.js
+++ b/dist/index.js
@@ -87624,12 +87624,16 @@ const jiraTicketRegex = new RegExp(
   'i'
 );
 
-const github = getOctokit_1(process.env.GITHUB_TOKEN);
+const token = process.env.GITHUB_TOKEN;
+if (!token) throw new Error('GITHUB_TOKEN is not set')
+const github = getOctokit_1(token);
 
 async function getJiraTicketsFromCommits() {
-  const {
-    data: [latestTag, previousTag],
-  } = await github.repos.listTags({ ...defaultApiParams, per_page: 2 });
+  const { data: tags } = await github.rest.repos.listTags({
+    ...defaultApiParams,
+    per_page: 2,
+  });
+  const [latestTag, previousTag] = tags;
 
   const [latestCommit, previousCommit] = await Promise.all([
     github.repos.getCommit({

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,8 +21,8 @@
         "rollup": "^2.77.2"
       },
       "engines": {
-        "node": ">=16",
-        "npm": ">=8.15"
+        "node": ">=20",
+        "npm": ">=10"
       }
     },
     "node_modules/@actions/core": {

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "Github Action which creates a new release in Jira to synchronize with the Release in Github.",
   "main": "dist/index.js",
   "engines": {
-    "node": ">=16",
-    "npm": ">=8.15"
+    "node": ">=20",
+    "npm": ">=10"
   },
   "scripts": {
     "build": "rollup -c rollup.config.js",

--- a/src/github-api-client.js
+++ b/src/github-api-client.js
@@ -12,7 +12,9 @@ const jiraTicketRegex = new RegExp(
   'i'
 )
 
-const github = getOctokit(process.env.GITHUB_TOKEN)
+const token = process.env.GITHUB_TOKEN;
+if (!token) throw new Error('GITHUB_TOKEN is not set');
+const github = getOctokit(token);
 
 async function getJiraTicketsFromCommits() {
   const {

--- a/src/github-api-client.js
+++ b/src/github-api-client.js
@@ -24,11 +24,11 @@ async function getJiraTicketsFromCommits() {
   const [latestTag, previousTag] = tags
 
   const [latestCommit, previousCommit] = await Promise.all([
-    github.repos.getCommit({
+    github.rest.repos.getCommit({
       ...defaultApiParams,
       ref: latestTag.commit.sha,
     }),
-    github.repos.getCommit({
+    github.rest.repos.getCommit({
       ...defaultApiParams,
       ref: previousTag.commit.sha,
     }),
@@ -39,7 +39,7 @@ async function getJiraTicketsFromCommits() {
     new Date(previousCommit.data.commit.committer.date).valueOf() + 1000
   ).toISOString()
 
-  const commits = await github.repos.listCommits({
+  const commits = await github.rest.repos.listCommits({
     ...defaultApiParams,
     since,
     until: latestCommit.data.commit.committer.date,

--- a/src/github-api-client.js
+++ b/src/github-api-client.js
@@ -12,14 +12,16 @@ const jiraTicketRegex = new RegExp(
   'i'
 )
 
-const token = process.env.GITHUB_TOKEN;
-if (!token) throw new Error('GITHUB_TOKEN is not set');
-const github = getOctokit(token);
+const token = process.env.GITHUB_TOKEN
+if (!token) throw new Error('GITHUB_TOKEN is not set')
+const github = getOctokit(token)
 
 async function getJiraTicketsFromCommits() {
-  const {
-    data: [latestTag, previousTag],
-  } = await github.repos.listTags({ ...defaultApiParams, per_page: 2 })
+  const { data: tags } = await github.rest.repos.listTags({
+    ...defaultApiParams,
+    per_page: 2,
+  })
+  const [latestTag, previousTag] = tags
 
   const [latestCommit, previousCommit] = await Promise.all([
     github.repos.getCommit({

--- a/src/jira-issues-updater.js
+++ b/src/jira-issues-updater.js
@@ -8,20 +8,30 @@ import getJiraTicketsFromCommits from './github-api-client'
 import jiraClient from './jira-client'
 
 async function updateJiraTickets(tickets, jiraVersion) {
-  const promises = tickets.map((t) => {
-    return jiraClient
-      .put(`rest/api/3/issue/${t}`, {
-        json: {
-          update: {
-            fixVersions: [
-              {
-                add: { name: jiraVersion },
-              },
-            ],
+  const promises = tickets.map(async (t) => {
+    try {
+      const response = await jiraClient
+        .put(`rest/api/3/issue/${t}`, {
+          json: {
+            update: {
+              fixVersions: [
+                {
+                  add: { name: jiraVersion },
+                },
+              ],
+            },
           },
-        },
-      })
-      .json()
+        })
+        .json()
+
+      return response
+    } catch (error) {
+      console.error(
+        `Failed to update issue ${t}:`,
+        error.response?.body || error
+      )
+      throw error
+    }
   })
 
   return await Promise.all(promises)

--- a/src/jira-release.js
+++ b/src/jira-release.js
@@ -10,9 +10,7 @@ async function run() {
 
     let jiraVersionName = `${context.repo.repo}-${tag_name.replace(/^v/, '')}`
 
-    const {
-      body: { data },
-    } = await jiraClient
+    const data = await jiraClient
       .post('rest/api/3/version', {
         json: {
           name: jiraVersionName,


### PR DESCRIPTION
In addition to resolving issue https://github.com/rodush/github-action-jira-release/issues/3

This PR also fixes several issues faced when testing the action on a personal repo.

- Remove code that is destructuring body.data when setting a Jira version, got().json() already returns the parsed JSON directly
- Use `github.rest.repos` in favor of `github.repos` (currently unsupported)
- Upgrade to Node 20
- Error handling and error console logging